### PR TITLE
Highlight component

### DIFF
--- a/src/components/Highlight/Highlight.module.scss
+++ b/src/components/Highlight/Highlight.module.scss
@@ -1,0 +1,3 @@
+.highlight {
+  box-shadow: inset 0 -0.5em rgb(var(--highlight-color));
+}

--- a/src/components/Highlight/index.tsx
+++ b/src/components/Highlight/index.tsx
@@ -1,0 +1,26 @@
+import { CSSProperties, PropsWithChildren } from "react";
+
+import { Colors } from "@ht6/react-ui/dist/styles";
+import { highlight } from "./Highlight.module.scss";
+
+export interface HighlightProps {
+  highlightColor: Colors;
+}
+
+export default function Highlight({
+  highlightColor,
+  children,
+}: PropsWithChildren<HighlightProps>) {
+  return (
+    <span
+      className={highlight}
+      style={
+        {
+          "--highlight-color": `var(--${highlightColor})`,
+        } as CSSProperties
+      }
+    >
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #12.  

Demo below. Doesn't exactly follow the design on Figma, but as per the discussion on the issue it should be good enough.
![image](https://user-images.githubusercontent.com/16544254/167240135-0e165fb6-640c-4923-b40e-f68411a04ce2.png)
